### PR TITLE
Don't show the prompt until the connection is established

### DIFF
--- a/ircdog.go
+++ b/ircdog.go
@@ -337,6 +337,7 @@ func runClient(
 	defer console.Close()
 	lineChan := make(chan string)
 	go func() {
+		<-lineChan // wait to show the prompt until connection established
 		for {
 			line, err := console.Readline()
 			if err == nil {
@@ -386,6 +387,7 @@ func connectExternal(
 		log.Printf("** ircdog connected to remote host at %s", connection.RemoteAddr().String())
 	}
 	defer connection.Disconnect()
+	lineChan <- "" // connection established, we can now call Readline()
 
 	doneChan := make(chan struct{})
 


### PR DESCRIPTION
72f81bed616aab12a5ab33167e470e51a7b359e9 changed things so that the first call to Readline() happens immediately, even before the connection is established. If the server is unavailable, this leads to a confusing user experience (the prompt is displayed, the first line of input is accepted, then the program hangs). Fix this by pausing the Readline() loop until the connection is established.